### PR TITLE
Configure and Apply Rubocop Suggestions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.6
+  NewCops: enable
 
 Style/StringLiterals:
   Enabled: true

--- a/eol_rb.gemspec
+++ b/eol_rb.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
     "bug_tracker_uri" => "https://github.com/Coolomina/eol-rb/issues",
-    "changelog_uri" => "https://github.com/Coolomina/eol-rb/releases"
+    "changelog_uri" => "https://github.com/Coolomina/eol-rb/releases",
+    "rubygems_mfa_required" => "true"
   }
 
   spec.files         = Dir["lib/**/*", "LICENSE.txt", "README.md", "CHANGELOG.md"]

--- a/eol_rb.gemspec
+++ b/eol_rb.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "rubocop", "~> 1.39"
+  spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.22"
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe EOL::Client do
       @stubs.get("/api/ruby.json") do
         [
           200,
-          { 'Content-Type': "application/json" },
+          { "Content-Type": "application/json" },
           '[{
             "cycle": "3.2",
             "eol": "2026-03-31",


### PR DESCRIPTION
Proactively opts into NewCops and adds the Suggested Extensions suggested by Rubocop. 

Split out of #1 as this is more opinion-based.

Based on these prompts:
```
❯ bundle exec rake rubocop
Running RuboCop...
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that you can opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable

Gemspec/DeprecatedAttributeAssignment: # new in 1.30
  Enabled: true
[...many other new cops...]
Style/SwapValues: # new in 1.1
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html
Inspecting 15 files
...............

15 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-rake (https://rubygems.org/gems/rubocop-rake)
  * rubocop-rspec (https://rubygems.org/gems/rubocop-rspec)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```